### PR TITLE
Make clang ignore type narrowing ...

### DIFF
--- a/Projects/Plugin/Plugin.jucer
+++ b/Projects/Plugin/Plugin.jucer
@@ -86,7 +86,8 @@
         <MODULEPATH id="juce_audio_utils" path="../../Submodules/JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
-    <LINUX_MAKE targetFolder="Builds/Linux" vstFolder="~/SDKs/VST3_SDK">
+    <LINUX_MAKE targetFolder="Builds/Linux" vstFolder="~/SDKs/VST3_SDK" extraCompilerFlags="-stdlib=libc++ -Wno-c++11-narrowing"
+                extraLinkerFlags="-stdlib=libc++">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" libraryPath="/usr/X11R6/lib/" isDebug="1" optimisation="1"
                        targetName="Soundboard" headerPath="..\..\..\..\Source\Plugin&#10;..\..\..\..\Source\Shared\Player&#10;..\..\..\..\Source\Shared\UserInterface&#10;..\..\..\..\Source\Shared\UserInterface\Grid&#10;..\..\..\..\Source\Shared\UserInterface\Settings&#10;..\..\..\..\Source\Shared\UserInterface\Table&#10;"/>

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ ___
 Dieses Kommando setzt den Loop Modus des Players. Mit 1.0 wird der Loop Modus eingeschaltet und mit 0.0 wird der Loop Modus ausgeschaltet.
 
 ___
-**/ultraschall/soundboard/player/*/fadeaut float (1.0)**
+**/ultraschall/soundboard/player/*/fadeout float (1.0)**
 
 Startet den Fade-Out eines laufenden Players.
 


### PR DESCRIPTION
... from int to char. This necessary due to some type conversion
sloppyness in VST3 code.