### PR TITLE
Workaround until the state gain bug is fixed

### DIFF
--- a/Source/Plugin/PluginProcessor.cpp
+++ b/Source/Plugin/PluginProcessor.cpp
@@ -321,9 +321,13 @@ void SoundboardAudioProcessor::getStateInformation(MemoryBlock& destData)
 
 void SoundboardAudioProcessor::setStateInformation(const void* data, int sizeInBytes)
 {
+    //FIXME: Workaround until the state gain bug is fixed
+    return;
+
     if (locked) {
         return;
     }
+
     ScopedPointer<XmlElement> xmlState(getXmlFromBinary(data, sizeInBytes));
     auto program = ValueTree::fromXml(*xmlState);
     if (program.isValid()) {


### PR DESCRIPTION
At the moment loading the states causes a reset (stopped playback) by the reaper ultraschall routing snapshots